### PR TITLE
change uniqueId

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -581,7 +581,7 @@ return n['koreader-sync'] && n['koreader-sync'].type == '${NoteType.SINGLE_NOTE}
         const uniqueId = crypto
           .createHash('md5')
           .update(
-            `${data[book].title} - ${data[book].authors} - ${data[book].bookmarks[bookmark].pos0} - ${data[book].bookmarks[bookmark].pos1}`
+            `${data[book].title} - ${data[book].authors} - ${data[book].bookmarks[bookmark].datetime}`
           )
           .digest('hex');
 


### PR DESCRIPTION
 To fix the problem of notes from pdf not being created.  

Example in pdf.lua file from Koreader :

 ["bookmarks"] = {
        [1] = {
            ["page"] = 286,
            ["chapter"] = "12. Routines: Workout Programs",
            ["datetime"] = "2022-12-07 22:17:38",
            ["notes"] = "True brawn and power are developed by hard training sessions, not by long training sessions. Quality over quantity is an excellent motto for strength.",
            ["pos0"] = {
                ["page"] = 286,
                ["x"] = 113.53055169962,
                ["rotation"] = 0,
                ["y"] = 94.348024444745,
                ["zoom"] = 2.4036458333333,
            },
            ["pos1"] = {
                ["page"] = 286,
                ["x"] = 355.4808284805,
                ["rotation"] = 0,
                ["y"] = 104.26570541035,
                ["zoom"] = 2.4036458333333,
            },

pos0 and pos1 not always a string, using datetime instead for uniqueId.